### PR TITLE
Reduce description size to below 125 chars

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,7 @@
 name: 'upload-dbfs-temp'
 description: >
   Upload a file on the local filesystem to a temporary DBFS location,
-  returning the DBFS path of the uploaded file. The file will be removed from DBFS at the end of the current GitHub
-  Workflow job.
+  returning the DBFS path of the uploaded file.
 inputs:
   local-path:
     description: >

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ outputs:
   dbfs-file-path:
     description: >
       The path in DBFS that the file was uploaded to, e.g. dbfs:/.../my-library.whl
+branding:
+  icon: 'upload-cloud'
+  color: 'orange'
 runs:
   using: 'node16'
   main: 'dist/main/index.js'


### PR DESCRIPTION
This is a prereq to publishing to marketplace

The fact that the temp file will be removed after github job run is included in README and can be removed.

Also add branding: an orange upload icon
<img width="223" alt="Screen Shot 2022-04-26 at 1 34 01 AM" src="https://user-images.githubusercontent.com/73549313/165258023-da1b6b32-2387-4f26-b2b4-4295e8a18311.png">
